### PR TITLE
refactor: enrich type hints across modules

### DIFF
--- a/tests/test_member_index.py
+++ b/tests/test_member_index.py
@@ -1,0 +1,41 @@
+"""Tests for member addition functions."""
+
+import trussme
+import pytest
+
+
+def test_add_member_returns_index() -> None:
+    """Ensure ``add_member`` returns the new member index."""
+    # Arrange
+    truss = trussme.Truss()
+    start = truss.add_free_joint([0.0, 0.0, 0.0])
+    end = truss.add_free_joint([1.0, 0.0, 0.0])
+
+    # Act
+    idx = truss.add_member(start, end)
+
+    # Assert
+    assert idx == 0
+
+
+def test_add_member_invalid_index() -> None:
+    """``add_member`` should raise when given an invalid joint index."""
+    # Arrange
+    truss = trussme.Truss()
+    valid = truss.add_free_joint([0.0, 0.0, 0.0])
+    _ = truss.add_free_joint([1.0, 0.0, 0.0])
+
+    # Act / Assert
+    with pytest.raises(IndexError):
+        truss.add_member(5, valid)
+
+
+def test_add_member_identical_indices() -> None:
+    """``add_member`` rejects using the same joint for both ends."""
+    # Arrange
+    truss = trussme.Truss()
+    joint = truss.add_free_joint([0.0, 0.0, 0.0])
+
+    # Act / Assert
+    with pytest.raises(ValueError):
+        truss.add_member(joint, joint)

--- a/trussme/report.py
+++ b/trussme/report.py
@@ -2,24 +2,24 @@ import json
 import io
 import re
 
-import matplotlib.pyplot
 import numpy
 import pandas
 import scipy
+from matplotlib.figure import Figure
 
 import trussme.visualize
 
 from trussme.truss import Truss, Goals
 
 
-def _fig_to_svg(fig: matplotlib.pyplot.Figure) -> str:
+def _fig_to_svg(fig: Figure) -> str:
     imgdata = io.StringIO()
     fig.savefig(imgdata, format="svg")
     imgdata.seek(0)  # rewind the data
 
     svg = imgdata.getvalue()
     svg = re.sub("<dc:date>(.*?)</dc:date>", "<dc:date></dc:date>", svg)
-    svg = re.sub("url\(#(.*?)\)", "url(#truss)", svg)
+    svg = re.sub(r"url\(#(.*?)\)", "url(#truss)", svg)
     svg = re.sub('<clipPath id="(.*?)">', '<clipPath id="truss">', svg)
 
     return svg
@@ -95,7 +95,7 @@ def report_to_md(
         f.write(report_to_str(truss, goals, with_figures=with_figures))
 
 
-def __generate_summary(truss, goals) -> str:
+def __generate_summary(truss: Truss, goals: Goals) -> str:
     """
     Generate a summary of the analysis.
 
@@ -121,8 +121,8 @@ def __generate_summary(truss, goals) -> str:
     )
     summary += "- The limit state is " + truss.limit_state + ".\n"
 
-    success_string = []
-    failure_string = []
+    success_string: list[str] = []
+    failure_string: list[str] = []
 
     if goals.minimum_fos_buckling < truss.fos_buckling:
         success_string.append("buckling FOS")
@@ -184,8 +184,8 @@ def __generate_summary(truss, goals) -> str:
                 summary += st + ","
             summary += "and " + str(failure_string[-1]) + " were not satisfied.\n"
 
-    data = []
-    rows = [
+    data: list[list[float | str]] = []
+    rows: list[str] = [
         "Minimum FOS for Buckling",
         "Minimum FOS for Yielding",
         "Maximum Mass",
@@ -232,7 +232,9 @@ def __generate_summary(truss, goals) -> str:
     return summary
 
 
-def __generate_instantiation_information(truss, with_figures: bool = True) -> str:
+def __generate_instantiation_information(
+    truss: Truss, with_figures: bool = True
+) -> str:
     """
     Generate a summary of the instantiation information.
 
@@ -255,11 +257,11 @@ def __generate_instantiation_information(truss, with_figures: bool = True) -> st
 
     # Print joint information
     instantiation += "## JOINTS\n"
-    data = []
-    rows = []
+    joint_data: list[list[str]] = []
+    joint_rows: list[str] = []
     for j in truss.joints:
-        rows.append("Joint_" + "{0:02d}".format(j.idx))
-        data.append(
+        joint_rows.append("Joint_" + "{0:02d}".format(j.idx))
+        joint_data.append(
             [
                 str(j.coordinates[0]),
                 str(j.coordinates[1]),
@@ -271,18 +273,18 @@ def __generate_instantiation_information(truss, with_figures: bool = True) -> st
         )
 
     instantiation += pandas.DataFrame(
-        data,
-        index=rows,
+        joint_data,
+        index=joint_rows,
         columns=["X", "Y", "Z", "X Support?", "Y Support?", "Z Support?"],
     ).to_markdown()
 
     # Print member information
     instantiation += "\n## MEMBERS\n"
-    data = []
-    rows = []
+    member_data: list[list[str | float]] = []
+    member_rows: list[str] = []
     for m in truss.members:
-        rows.append("Member_" + "{0:02d}".format(m.idx))
-        data.append(
+        member_rows.append("Member_" + "{0:02d}".format(m.idx))
+        member_data.append(
             [
                 str(m.begin_joint.idx),
                 str(m.end_joint.idx),
@@ -298,8 +300,8 @@ def __generate_instantiation_information(truss, with_figures: bool = True) -> st
         )
 
     instantiation += pandas.DataFrame(
-        data,
-        index=rows,
+        member_data,
+        index=member_rows,
         columns=[
             "Beginning Joint",
             "Ending Joint",
@@ -312,11 +314,11 @@ def __generate_instantiation_information(truss, with_figures: bool = True) -> st
 
     # Print material list
     instantiation += "\n## MATERIALS\n"
-    data = []
-    rows = []
+    material_data: list[list[str]] = []
+    material_rows: list[str] = []
     for mat in truss.materials:
-        rows.append(mat["name"])
-        data.append(
+        material_rows.append(mat["name"])
+        material_data.append(
             [
                 str(mat["density"]),
                 str(mat["elastic_modulus"] / pow(10, 9)),
@@ -325,8 +327,8 @@ def __generate_instantiation_information(truss, with_figures: bool = True) -> st
         )
 
     instantiation += pandas.DataFrame(
-        data,
-        index=rows,
+        material_data,
+        index=material_rows,
         columns=[
             "Density (kg/m3)",
             "Elastic Modulus (GPa)",
@@ -337,7 +339,9 @@ def __generate_instantiation_information(truss, with_figures: bool = True) -> st
     return instantiation
 
 
-def __generate_stress_analysis(truss, goals, with_figures: bool = True) -> str:
+def __generate_stress_analysis(
+    truss: Truss, goals: Goals, with_figures: bool = True
+) -> str:
     """
     Generate a summary of the stress analysis information.
 
@@ -359,11 +363,11 @@ def __generate_stress_analysis(truss, goals, with_figures: bool = True) -> str:
 
     # Print information about loads
     analysis += "## LOADING\n"
-    data = []
-    rows = []
+    load_data: list[list[str]] = []
+    load_rows: list[str] = []
     for j in truss.joints:
-        rows.append("Joint_" + "{0:02d}".format(j.idx))
-        data.append(
+        load_rows.append("Joint_" + "{0:02d}".format(j.idx))
+        load_data.append(
             [
                 str(j.loads[0] / pow(10, 3)),
                 format(
@@ -379,32 +383,38 @@ def __generate_stress_analysis(truss, goals, with_figures: bool = True) -> str:
         )
 
     analysis += pandas.DataFrame(
-        data, index=rows, columns=["X Load", "Y Load", "Z Load"]
+        load_data, index=load_rows, columns=["X Load", "Y Load", "Z Load"]
     ).to_markdown()
 
     # Print information about reactions
     analysis += "\n## REACTIONS\n"
-    data = []
-    rows = []
+    reaction_data: list[list[str]] = []
+    reaction_rows: list[str] = []
     for j in truss.joints:
-        rows.append("Joint_" + "{0:02d}".format(j.idx))
-        data.append(
+        reaction_rows.append("Joint_" + "{0:02d}".format(j.idx))
+        reaction_data.append(
             [
-                format(j.reactions[0] / pow(10, 3), ".2f")
-                if j.translation_restricted[0] != 0.0
-                else "N/A",
-                format(j.reactions[1] / pow(10, 3), ".2f")
-                if j.translation_restricted[1] != 0.0
-                else "N/A",
-                format(j.reactions[2] / pow(10, 3), ".2f")
-                if j.translation_restricted[2] != 0.0
-                else "N/A",
+                (
+                    format(j.reactions[0] / pow(10, 3), ".2f")
+                    if j.translation_restricted[0] != 0.0
+                    else "N/A"
+                ),
+                (
+                    format(j.reactions[1] / pow(10, 3), ".2f")
+                    if j.translation_restricted[1] != 0.0
+                    else "N/A"
+                ),
+                (
+                    format(j.reactions[2] / pow(10, 3), ".2f")
+                    if j.translation_restricted[2] != 0.0
+                    else "N/A"
+                ),
             ]
         )
 
     analysis += pandas.DataFrame(
-        data,
-        index=rows,
+        reaction_data,
+        index=reaction_rows,
         columns=["X Reaction (kN)", "Y Reaction (kN)", "Z Reaction (kN)"],
     ).to_markdown()
 
@@ -417,11 +427,11 @@ def __generate_stress_analysis(truss, goals, with_figures: bool = True) -> str:
             + "\n"
         )
 
-    data = []
-    rows = []
+    member_data: list[list[str | float]] = []
+    member_rows: list[str] = []
     for m in truss.members:
-        rows.append("Member_" + "{0:02d}".format(m.idx))
-        data.append(
+        member_rows.append("Member_" + "{0:02d}".format(m.idx))
+        member_data.append(
             [
                 m.area,
                 format(m.moment_of_inertia, ".2e"),
@@ -429,15 +439,17 @@ def __generate_stress_analysis(truss, goals, with_figures: bool = True) -> str:
                 m.fos_yielding,
                 "Yes" if m.fos_yielding > goals.minimum_fos_yielding else "No",
                 m.fos_buckling if m.fos_buckling > 0 else "N/A",
-                "Yes"
-                if m.fos_buckling > goals.minimum_fos_buckling or m.fos_buckling < 0
-                else "No",
+                (
+                    "Yes"
+                    if m.fos_buckling > goals.minimum_fos_buckling or m.fos_buckling < 0
+                    else "No"
+                ),
             ]
         )
 
     analysis += pandas.DataFrame(
-        data,
-        index=rows,
+        member_data,
+        index=member_rows,
         columns=[
             "Area (m^2)",
             "Moment of Inertia (m^4)",
@@ -462,30 +474,38 @@ def __generate_stress_analysis(truss, goals, with_figures: bool = True) -> str:
             + "\n"
         )
 
-    data = []
-    rows = []
+    deflection_data: list[list[str]] = []
+    deflection_rows: list[str] = []
     for j in truss.joints:
-        rows.append("Joint_" + "{0:02d}".format(j.idx))
-        data.append(
+        deflection_rows.append("Joint_" + "{0:02d}".format(j.idx))
+        deflection_data.append(
             [
-                format(j.deflections[0] * pow(10, 3), ".5f")
-                if j.translation_restricted[0] == 0.0
-                else "N/A",
-                format(j.deflections[1] * pow(10, 3), ".5f")
-                if j.translation_restricted[1] == 0.0
-                else "N/A",
-                format(j.deflections[2] * pow(10, 3), ".5f")
-                if j.translation_restricted[2] == 0.0
-                else "N/A",
-                "Yes"
-                if numpy.linalg.norm(j.deflections) < goals.maximum_deflection
-                else "No",
+                (
+                    format(j.deflections[0] * pow(10, 3), ".5f")
+                    if j.translation_restricted[0] == 0.0
+                    else "N/A"
+                ),
+                (
+                    format(j.deflections[1] * pow(10, 3), ".5f")
+                    if j.translation_restricted[1] == 0.0
+                    else "N/A"
+                ),
+                (
+                    format(j.deflections[2] * pow(10, 3), ".5f")
+                    if j.translation_restricted[2] == 0.0
+                    else "N/A"
+                ),
+                (
+                    "Yes"
+                    if numpy.linalg.norm(j.deflections) < goals.maximum_deflection
+                    else "No"
+                ),
             ]
         )
 
     analysis += pandas.DataFrame(
-        data,
-        index=rows,
+        deflection_data,
+        index=deflection_rows,
         columns=[
             "X Deflection(mm)",
             "Y Deflection (mm)",

--- a/trussme/truss.py
+++ b/trussme/truss.py
@@ -107,7 +107,9 @@ class Truss(object):
     @property
     def deflection(self) -> float:
         """float: Largest single joint deflection in the truss"""
-        return max([numpy.linalg.norm(joint.deflections) for joint in self.joints])
+        return float(
+            max([numpy.linalg.norm(joint.deflections) for joint in self.joints])
+        )
 
     @property
     def materials(self) -> list[Material]:
@@ -243,7 +245,9 @@ class Truss(object):
 
         return self.joints[-1].idx
 
-    def add_out_of_plane_support(self, constrained_axis: Literal["x", "y", "z"] = "z"):
+    def add_out_of_plane_support(
+        self, constrained_axis: Literal["x", "y", "z"] = "z"
+    ) -> None:
         for idx in range(self.number_of_joints):
             if constrained_axis == "x":
                 self.joints[idx].translation_restricted[0] = True
@@ -258,7 +262,7 @@ class Truss(object):
         end_joint_index: int,
         material: Material = MATERIAL_LIBRARY[0],
         shape: Shape = Pipe(t=0.002, r=0.02),
-    ):
+    ) -> int:
         """
         Add a member to the truss
 
@@ -277,7 +281,22 @@ class Truss(object):
         -------
         int
             The index of the new member
+
+        Raises
+        ------
+        IndexError
+            If ``begin_joint_index`` or ``end_joint_index`` are out of range.
+        ValueError
+            If ``begin_joint_index`` and ``end_joint_index`` refer to the same joint.
         """
+        if not 0 <= begin_joint_index < self.number_of_joints:
+            msg = f"begin_joint_index {begin_joint_index} is out of range"
+            raise IndexError(msg)
+        if not 0 <= end_joint_index < self.number_of_joints:
+            msg = f"end_joint_index {end_joint_index} is out of range"
+            raise IndexError(msg)
+        if begin_joint_index == end_joint_index:
+            raise ValueError("begin_joint_index and end_joint_index must differ")
 
         member = Member(
             self.joints[begin_joint_index],
@@ -294,7 +313,9 @@ class Truss(object):
         self.joints[begin_joint_index].members.append(self.members[-1])
         self.joints[end_joint_index].members.append(self.members[-1])
 
-    def move_joint(self, joint_index: int, coordinates: list[float]):
+        return member.idx
+
+    def move_joint(self, joint_index: int, coordinates: list[float]) -> None:
         """
         Move a joint to the given coordinates
 
@@ -311,7 +332,7 @@ class Truss(object):
         """
         self.joints[joint_index].coordinates = coordinates
 
-    def set_load(self, joint_index: int, load: list[float]):
+    def set_load(self, joint_index: int, load: list[float]) -> None:
         """Apply loads to a given joint
         Parameters
         ----------
@@ -347,7 +368,7 @@ class Truss(object):
             [[member.begin_joint.idx, member.end_joint.idx] for member in self.members]
         ).T
 
-    def analyze(self):
+    def analyze(self) -> None:
         """
         Analyze the truss
 
@@ -424,6 +445,8 @@ class Truss(object):
         for i in range(self.number_of_members):
             self.members[i].force = forces[i]
 
+        return None
+
     def to_json(self, file_name: Union[None, str] = None) -> Union[str, None]:
         """
         Saves the truss to a JSON file
@@ -479,6 +502,7 @@ class Truss(object):
         else:
             with open(file_name, "w") as f:
                 json.dump(combined, f, indent=4)
+            return None
 
     def to_trs(self, file_name: str) -> None:
         """

--- a/trussme/visualize.py
+++ b/trussme/visualize.py
@@ -1,19 +1,24 @@
 from typing import Literal, Any, Optional, Union
 
+import matplotlib.colors
 import matplotlib.pyplot
 import numpy
+
+from matplotlib.figure import Figure
+
+from trussme.truss import Truss
 
 MatplotlibColor = Any
 """Type: New type to represent a matplotlib color, simply an alias of Any"""
 
 
 def plot_truss(
-    truss,
+    truss: Truss,
     starting_shape: Optional[Union[Literal["fos", "force"], MatplotlibColor]] = "k",
     deflected_shape: Optional[Union[Literal["fos", "force"], MatplotlibColor]] = None,
     exaggeration_factor: float = 10,
     fos_threshold: float = 1.0,
-) -> matplotlib.pyplot.Figure:
+) -> Figure:
     """Plot the truss.
 
     Parameters
@@ -39,7 +44,7 @@ def plot_truss(
         A matplotlib figure containing the truss
     """
 
-    fig = matplotlib.pyplot.figure()
+    fig: Figure = matplotlib.pyplot.figure()
     ax = fig.add_subplot(
         111,
     )
@@ -55,37 +60,39 @@ def plot_truss(
     )
 
     for member in truss.members:
+        start_color: MatplotlibColor
         if starting_shape == "fos":
-            color = (
+            start_color = (
                 "g"
                 if numpy.min([member.fos_buckling, member.fos_yielding]) > fos_threshold
                 else "r"
             )
         elif starting_shape == "force":
-            color = force_colormap(member.force / (2 * scaler) + 0.5)
+            start_color = force_colormap(member.force / (2 * scaler) + 0.5)
         elif starting_shape is None:
             break
         else:
-            color = starting_shape
+            start_color = starting_shape
         ax.plot(
             [member.begin_joint.coordinates[0], member.end_joint.coordinates[0]],
             [member.begin_joint.coordinates[1], member.end_joint.coordinates[1]],
-            color=color,
+            color=start_color,
         )
 
     for member in truss.members:
+        def_color: MatplotlibColor
         if deflected_shape == "fos":
-            color = (
+            def_color = (
                 "g"
                 if numpy.min([member.fos_buckling, member.fos_yielding]) > fos_threshold
                 else "r"
             )
         elif deflected_shape == "force":
-            color = force_colormap(member.force / (2 * scaler) + 0.5)
+            def_color = force_colormap(member.force / (2 * scaler) + 0.5)
         elif deflected_shape is None:
             break
         else:
-            color = deflected_shape
+            def_color = deflected_shape
         ax.plot(
             [
                 member.begin_joint.coordinates[0]
@@ -99,7 +106,7 @@ def plot_truss(
                 member.end_joint.coordinates[1]
                 + exaggeration_factor * member.end_joint.deflections[1],
             ],
-            color=color,
+            color=def_color,
         )
 
     return fig


### PR DESCRIPTION
## Summary
- add explicit return types and member index return to `Truss`
- tighten typing in reporting and visualization utilities
- cover `add_member` index with a regression test
- validate member indices before adding members and test error paths

## Testing
- `ruff check trussme/truss.py tests/test_member_index.py`
- `mypy --ignore-missing-imports --follow-imports=skip trussme/truss.py tests/test_member_index.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb6152fcc08325b101b91f099829c2